### PR TITLE
changes in Readme

### DIFF
--- a/boxes/README.md
+++ b/boxes/README.md
@@ -13,7 +13,7 @@ since, Vagrant uses Oracle VM VirtualBox as the default provider.
 
 ##### 1. Checkout this repository into your local machine using the following Git command.
 ```
-git clone https://github.com/wso2-incubator/vagrant-is.git
+git clone https://github.com/wso2/vagrant-is.git
 ```
 
 ##### 2. Move to `boxes` folder.

--- a/machines/README.md
+++ b/machines/README.md
@@ -14,7 +14,7 @@ for MySQL, [Connector/J](https://dev.mysql.com/downloads/connector/j/5.1.html).
 
 ##### 1. Checkout this repository into your local machine using the following Git command.
 ```
-git clone https://github.com/wso2-incubator/vagrant-is.git
+git clone https://github.com/wso2/vagrant-is.git
 ```
 
 ##### 2. Build and add the Vagrant boxes for external MySQL database, WSO2 Identity Server and WSO2 Identity Server Analytics using the Vagrant box generation resources.


### PR DESCRIPTION
## Purpose
> Changing the git clone URL in the readme after moving from the incubator to wso2
